### PR TITLE
Global printf implemented as a define

### DIFF
--- a/src/lib/PrintExtension.cpp
+++ b/src/lib/PrintExtension.cpp
@@ -52,6 +52,23 @@
 
     #define PRINTF_CONVERT_BUFFER_LEN   24
     #define PRINTF_ERROR_MESSAGE        "Error" //F("Error") may be used also.
+	
+	#ifndef PRINTEX_NO_STDOUT
+	
+		Print *PrintEx::_stdout = &Serial;
+		namespace std{
+		#ifndef PRINTEX_NO_PROGMEM
+			pft printf( const __FlashStringHelper *format, ... ){
+				va_list vList;
+				va_start( vList, format );
+				PrintEx p(*PrintEx::_stdout);
+				const pft p_Return = p._printf(format, strlen_P((const char*)format)+1, vList);
+				va_end( vList );
+				return p_Return;				
+			}
+		#endif
+		}
+	#endif	
 
     /****************************************************************
         GetParam_XXX functions.

--- a/src/lib/PrintExtension.cpp
+++ b/src/lib/PrintExtension.cpp
@@ -92,7 +92,7 @@
     #ifndef PRINTEX_NO_STDOUT
 
         //Storage location for 'stdout' Print pointer.
-        Print *_stdout = (Print*) 0x00;
+        Print *_stdout __attribute__((weak)) = (Print*) 0x00;
 
         pft PRINTF_ALIAS( const char *format, ... ){
             if( !_stdout ) return 0;

--- a/src/lib/PrintExtension.cpp
+++ b/src/lib/PrintExtension.cpp
@@ -92,9 +92,10 @@
     #ifndef PRINTEX_NO_STDOUT
 
         //Storage location for 'stdout' Print pointer.
-        Print *PrintEx::_stdout = &Serial;
+        Print *PrintEx::_stdout = (Print*) 0x00;
 
         pft PRINTF_ALIAS( const char *format, ... ){
+            if( !PrintEx::_stdout ) return 0;
             va_list vList;
             va_start( vList, format );
             const pft p_Return = PrintEx(*PrintEx::_stdout)._printf( format, vList );
@@ -104,6 +105,7 @@
 
         #ifndef PRINTEX_NO_PROGMEM
             pft PRINTF_ALIAS( const __FlashStringHelper *format, ... ){
+                if( !PrintEx::_stdout ) return 0;
                 va_list vList;
                 va_start( vList, format );
                 const pft p_Return = PrintEx(*PrintEx::_stdout)._printf( format, strlen_P((const char*)format)+1, vList );

--- a/src/lib/PrintExtension.cpp
+++ b/src/lib/PrintExtension.cpp
@@ -92,23 +92,23 @@
     #ifndef PRINTEX_NO_STDOUT
 
         //Storage location for 'stdout' Print pointer.
-        Print *PrintEx::_stdout = (Print*) 0x00;
+        Print *_stdout = (Print*) 0x00;
 
         pft PRINTF_ALIAS( const char *format, ... ){
-            if( !PrintEx::_stdout ) return 0;
+            if( !_stdout ) return 0;
             va_list vList;
             va_start( vList, format );
-            const pft p_Return = PrintEx(*PrintEx::_stdout)._printf( format, vList );
+            const pft p_Return = PrintEx(*_stdout)._printf( format, vList );
             va_end( vList );
             return p_Return;
         }
 
         #ifndef PRINTEX_NO_PROGMEM
             pft PRINTF_ALIAS( const __FlashStringHelper *format, ... ){
-                if( !PrintEx::_stdout ) return 0;
+                if( !_stdout ) return 0;
                 va_list vList;
                 va_start( vList, format );
-                const pft p_Return = PrintEx(*PrintEx::_stdout)._printf( format, strlen_P((const char*)format)+1, vList );
+                const pft p_Return = PrintEx(*_stdout)._printf( format, strlen_P((const char*)format)+1, vList );
                 va_end( vList );
                 return p_Return;
             }

--- a/src/lib/PrintExtension.cpp
+++ b/src/lib/PrintExtension.cpp
@@ -52,10 +52,14 @@
 
     #define PRINTF_CONVERT_BUFFER_LEN   24
     #define PRINTF_ERROR_MESSAGE        "Error" //F("Error") may be used also.
-	
-	#ifndef PRINTEX_NO_STDOUT
-		Print *PrintEx::_stdout = &Serial;
-	#endif	
+
+    #ifndef PRINTEX_NO_STDOUT
+        Print *PrintEx::_stdout = &Serial;
+    #endif
+
+    #ifdef printf
+        #undef printf
+    #endif
 
     /****************************************************************
         GetParam_XXX functions.
@@ -143,7 +147,7 @@
     ****************************************************************/
 
     #ifndef PRINTEX_NO_PROGMEM
-        pft PrintExtension::printf( const __FlashStringHelper *format, ... ){
+        pft PrintExtension::printf__( const __FlashStringHelper *format, ... ){
             va_list vList;
             va_start( vList, format );
             const pft p_Return = _printf( format, strlen_P((const char*)format)+1, vList );
@@ -159,7 +163,7 @@
 
 
 
-    pft PrintExtension::printf( const char *format, ... ){
+    pft PrintExtension::printf__( const char *format, ... ){
         va_list vList;
         va_start( vList, format );
         const pft p_Return = _printf( format, vList );

--- a/src/lib/PrintExtension.cpp
+++ b/src/lib/PrintExtension.cpp
@@ -54,20 +54,7 @@
     #define PRINTF_ERROR_MESSAGE        "Error" //F("Error") may be used also.
 	
 	#ifndef PRINTEX_NO_STDOUT
-	
 		Print *PrintEx::_stdout = &Serial;
-		namespace std{
-		#ifndef PRINTEX_NO_PROGMEM
-			pft printf( const __FlashStringHelper *format, ... ){
-				va_list vList;
-				va_start( vList, format );
-				PrintEx p(*PrintEx::_stdout);
-				const pft p_Return = p._printf(format, strlen_P((const char*)format)+1, vList);
-				va_end( vList );
-				return p_Return;				
-			}
-		#endif
-		}
 	#endif	
 
     /****************************************************************

--- a/src/lib/PrintExtension.h
+++ b/src/lib/PrintExtension.h
@@ -36,7 +36,7 @@
     #define PRINTEX_LARGE_COUNTER
 
     #define PRINTEX_NO_SPRINTF
-	#define PRINTEX_NO_STDOUT
+    #define PRINTEX_NO_STDOUT
 ********************************************************************************/
 
 #include "Arduino.h"
@@ -55,18 +55,6 @@
     #else
         typedef uint8_t pfct;
     #endif
-	
-	namespace std{
-		#ifndef PRINTEX_NO_STDOUT
-		
-			template<signed N>
-			pft printf( const char (&format)[N], ... );
-			
-			#ifndef PRINTEX_NO_PROGMEM
-				pft printf( const __FlashStringHelper *format, ... );
-			#endif
-		#endif
-	};			
 
     class PrintExtension
         :   public Print,
@@ -89,16 +77,6 @@
 
             pft _printf( const char *format, const va_list &v_List );
 
-			#ifndef PRINTEX_NO_STDOUT
-			
-				template<signed N>
-				friend pft std::printf( const char (&format)[N], ... );
-				
-				#ifndef PRINTEX_NO_PROGMEM
-					friend pft std::printf( const __FlashStringHelper *format, ... );
-				#endif
-			#endif
-
             #ifndef PRINTEX_NO_PROGMEM
                 pft _printf( const __FlashStringHelper *format, const int count, const va_list &vList );
             #endif
@@ -119,10 +97,10 @@
         static PrintExWrap<T> &wrap( T &t ){
             return *transform<PrintExWrap<T>*, T*>(&t);
         }
-		
-		#ifndef PRINTEX_NO_STDOUT
-			static Print *_stdout;
-		#endif
+
+        #ifndef PRINTEX_NO_STDOUT
+            static Print *_stdout;
+        #endif
     };
 
     template<typename T>
@@ -187,25 +165,9 @@
     #ifndef PRINTEX_NO_SPRINTF
         #define sprintf(buff, str, ...) GString(buff).printf(str, __VA_ARGS__);
     #endif
-	namespace std{
-		#ifndef PRINTEX_NO_STDOUT
-		
-			template<signed N>
-			pft printf( const char (&format)[N], ... ){
-				va_list vList;
-				va_start( vList, format );
-				PrintEx p = *PrintEx::_stdout;			
-				const pft p_Return = p._printf(format, vList);
-				va_end( vList );
-				return p_Return;	
-			}
-			
-			#ifndef PRINTEX_NO_PROGMEM
-				pft printf( const __FlashStringHelper *format, ... );
-			#endif
-		#endif
-	};
-	
-	//using ::std::printf;
 
+    // A workaround for global printf. Use xprintf to use PrintEx features.
+    #ifndef PRINTEX_NO_STDOUT
+        #define xprintf(str, ...) PrintEx(*PrintEx::_stdout).printf(str, __VA_ARGS__);
+    #endif
 #endif

--- a/src/lib/PrintExtension.h
+++ b/src/lib/PrintExtension.h
@@ -64,13 +64,16 @@
             public PrintVariadic<PrintExtension>{
         public:
 
-            pft printf( const char *format, ... );
+            pft printf__( const char *format, ... );
 
             #ifndef PRINTEX_NO_PROGMEM
-                pft printf( const __FlashStringHelper *format, ... );
+                pft printf__( const __FlashStringHelper *format, ... );
             #endif
 
         protected:
+
+            friend pft printf__( const char *format, ... );
+            friend pft printf__( const __FlashStringHelper *format, ... );
 
             friend class StreamExtension;
             template<typename T> friend struct PrintExWrap;
@@ -168,6 +171,27 @@
 
     // A workaround for global printf. Use xprintf to use PrintEx features.
     #ifndef PRINTEX_NO_STDOUT
-        #define xprintf(str, ...) PrintEx(*PrintEx::_stdout).printf(str, __VA_ARGS__);
+
+        #define printf(format, ...)  printf__(format, __VA_ARGS__)
+
+        inline pft printf__( const char *format, ... ){
+            va_list vList;
+            va_start( vList, format );
+            const pft p_Return = PrintEx(*PrintEx::_stdout)._printf( format, vList );
+            va_end( vList );
+            return p_Return;
+        }
+
+        #ifndef PRINTEX_NO_PROGMEM
+            inline pft printf__( const __FlashStringHelper *format, ... ){
+                va_list vList;
+                va_start( vList, format );
+                const pft p_Return = PrintEx(*PrintEx::_stdout)._printf( format, strlen_P((const char*)format)+1, vList );
+                va_end( vList );
+                return p_Return;
+            }
+        #endif
+
+        #define xprintf(str, ...) PrintEx(*PrintEx::_stdout).printf__(str, __VA_ARGS__);
     #endif
 #endif

--- a/src/lib/PrintExtension.h
+++ b/src/lib/PrintExtension.h
@@ -63,12 +63,34 @@
         #define PRINTF_ALIAS    printf__
     #endif
 
+    /***
+        stdout handling.
+        The global function printf uses _stdout as a target for printing.
+    ***/
+
+    #ifndef PRINTEX_NO_STDOUT
+        extern Print *_stdout;
+        inline static void set_stdout( Print &out ){ _stdout = &out; }
+        inline static void clear_stdout(){ _stdout = (Print*) 0x00; }
+    #endif
+
+    template< typename derived >
+    struct PrintfSupport{
+
+        #ifndef PRINTEX_NO_STDOUT
+            static Print *_stdout;
+            inline void set_stdout(){ ::_stdout = CRTPP; }
+            inline void clear_stdout(){ ::_stdout = (Print*) 0x00; }
+        #endif
+    };
+
     class PrintExtension
         :   public Print,
             public PrintConcat<PrintExtension>,
             public PrintRepeat<PrintExtension>,
             public ios::OStreamBase<PrintExtension>,
-            public PrintVariadic<PrintExtension>{
+            public PrintVariadic<PrintExtension>,
+            public PrintfSupport<PrintExtension>{
         public:
 
             pft PRINTF_ALIAS( const char *format, ... );
@@ -115,17 +137,6 @@
         static PrintExWrap<T> &wrap( T &t ){
             return *transform<PrintExWrap<T>*, T*>(&t);
         }
-
-        /***
-            stdout handling.
-            The global function printf uses _stdout as a target for printing.
-        ***/
-
-        #ifndef PRINTEX_NO_STDOUT
-            static Print *_stdout;
-            inline static void set_stdout( Print &out ){ PrintEx::_stdout = &out; }
-            inline static void clear_stdout(){ PrintEx::_stdout = (Print*) 0x00; }
-        #endif
     };
 
     template<typename T>
@@ -134,6 +145,7 @@
             PrintRepeat< PrintExWrap<T> >,
             ios::OStreamBase< PrintExWrap<T> >,
             PrintVariadic< PrintExWrap<T> >,
+            PrintfSupport< PrintExWrap<T> >,
             T{
 
         /***

--- a/src/lib/PrintExtension.h
+++ b/src/lib/PrintExtension.h
@@ -56,6 +56,13 @@
         typedef uint8_t pfct;
     #endif
 
+    //If using a #define to override printf, give the actual printf another name (printf__).
+    #ifdef PRINTEX_NO_STDOUT
+        #define PRINTF_ALIAS    printf
+    #else
+        #define PRINTF_ALIAS    printf__
+    #endif
+
     class PrintExtension
         :   public Print,
             public PrintConcat<PrintExtension>,
@@ -64,16 +71,16 @@
             public PrintVariadic<PrintExtension>{
         public:
 
-            pft printf__( const char *format, ... );
+            pft PRINTF_ALIAS( const char *format, ... );
 
             #ifndef PRINTEX_NO_PROGMEM
-                pft printf__( const __FlashStringHelper *format, ... );
+                pft PRINTF_ALIAS( const __FlashStringHelper *format, ... );
             #endif
 
         protected:
 
-            friend pft printf__( const char *format, ... );
-            friend pft printf__( const __FlashStringHelper *format, ... );
+            friend pft PRINTF_ALIAS( const char *format, ... );
+            friend pft PRINTF_ALIAS( const __FlashStringHelper *format, ... );
 
             friend class StreamExtension;
             template<typename T> friend struct PrintExWrap;
@@ -142,7 +149,7 @@
             Pass through allowing use of PrintExtension::printf.
         ***/
 
-        pft printf__( const char *format, ... ){
+        pft PRINTF_ALIAS( const char *format, ... ){
             va_list vList;
             va_start( vList, format );
             PrintEx p = *this;
@@ -152,7 +159,7 @@
         }
 
         #ifndef PRINTEX_NO_PROGMEM
-            pft printf__( const __FlashStringHelper *format, ... ){
+            pft PRINTF_ALIAS( const __FlashStringHelper *format, ... ){
                 va_list vList;
                 va_start( vList, format );
                 PrintEx p = *this;
@@ -171,27 +178,11 @@
 
     // A workaround for global printf. Use xprintf to use PrintEx features.
     #ifndef PRINTEX_NO_STDOUT
-
-        #define printf(format, ...)  printf__(format, __VA_ARGS__)
-
-        inline pft printf__( const char *format, ... ){
-            va_list vList;
-            va_start( vList, format );
-            const pft p_Return = PrintEx(*PrintEx::_stdout)._printf( format, vList );
-            va_end( vList );
-            return p_Return;
-        }
+        #define printf(format, ...)  PRINTF_ALIAS(format, __VA_ARGS__)
+         pft PRINTF_ALIAS( const char *format, ... );
 
         #ifndef PRINTEX_NO_PROGMEM
-            inline pft printf__( const __FlashStringHelper *format, ... ){
-                va_list vList;
-                va_start( vList, format );
-                const pft p_Return = PrintEx(*PrintEx::_stdout)._printf( format, strlen_P((const char*)format)+1, vList );
-                va_end( vList );
-                return p_Return;
-            }
+            pft PRINTF_ALIAS( const __FlashStringHelper *format, ... );
         #endif
-
-        #define xprintf(str, ...) PrintEx(*PrintEx::_stdout).printf__(str, __VA_ARGS__);
     #endif
 #endif

--- a/src/lib/PrintExtension.h
+++ b/src/lib/PrintExtension.h
@@ -142,7 +142,7 @@
             Pass through allowing use of PrintExtension::printf.
         ***/
 
-        pft printf( const char *format, ... ){
+        pft printf__( const char *format, ... ){
             va_list vList;
             va_start( vList, format );
             PrintEx p = *this;
@@ -152,7 +152,7 @@
         }
 
         #ifndef PRINTEX_NO_PROGMEM
-            pft printf( const __FlashStringHelper *format, ... ){
+            pft printf__( const __FlashStringHelper *format, ... ){
                 va_list vList;
                 va_start( vList, format );
                 PrintEx p = *this;

--- a/src/lib/PrintExtension.h
+++ b/src/lib/PrintExtension.h
@@ -123,7 +123,8 @@
 
         #ifndef PRINTEX_NO_STDOUT
             static Print *_stdout;
-            inline static set_stdout( Print &out ){ _stdout = &out; }
+            inline static void set_stdout( Print &out ){ PrintEx::_stdout = &out; }
+            inline static void clear_stdout(){ PrintEx::_stdout = (Print*) 0x00; }
         #endif
     };
 

--- a/src/lib/PrintExtension.h
+++ b/src/lib/PrintExtension.h
@@ -173,8 +173,8 @@
 
     // Global sprintf replacement. To keep old version define PRINTEX_NO_SPRINTF (does not affect x.printf();)
     #ifndef PRINTEX_NO_SPRINTF
-        #define sprintf(buff, str, ...) GString(buff).printf(str, __VA_ARGS__);
-        #define xprintf(out, str, ...) PrintEx(out).PRINTF_ALIAS(str, __VA_ARGS__);
+        #define sprintf(buff, str, ...) GString(buff).printf(str, __VA_ARGS__)
+        #define xprintf(out, str, ...) PrintEx(out).PRINTF_ALIAS(str, __VA_ARGS__)
     #endif
 
     // A workaround for global printf. Use xprintf to use PrintEx features.

--- a/src/lib/PrintExtension.h
+++ b/src/lib/PrintExtension.h
@@ -123,7 +123,7 @@
 
         #ifndef PRINTEX_NO_STDOUT
             static Print *_stdout;
-            inline static set_stdout( Print *out ){ _stdout = out; }
+            inline static set_stdout( Print &out ){ _stdout = &out; }
         #endif
     };
 

--- a/src/lib/PrintExtension.h
+++ b/src/lib/PrintExtension.h
@@ -174,6 +174,7 @@
     // Global sprintf replacement. To keep old version define PRINTEX_NO_SPRINTF (does not affect x.printf();)
     #ifndef PRINTEX_NO_SPRINTF
         #define sprintf(buff, str, ...) GString(buff).printf(str, __VA_ARGS__);
+        #define xprintf(out, str, ...) PrintEx(out).PRINTF_ALIAS(str, __VA_ARGS__);
     #endif
 
     // A workaround for global printf. Use xprintf to use PrintEx features.

--- a/src/lib/PrintExtension.h
+++ b/src/lib/PrintExtension.h
@@ -78,7 +78,6 @@
     struct PrintfSupport{
 
         #ifndef PRINTEX_NO_STDOUT
-            static Print *_stdout;
             inline void set_stdout(){ ::_stdout = CRTPP; }
             inline void clear_stdout(){ ::_stdout = (Print*) 0x00; }
         #endif

--- a/src/lib/PrintExtension.h
+++ b/src/lib/PrintExtension.h
@@ -103,13 +103,27 @@
         size_t write( uint8_t data )      { return out.write( data ); }
         Print &out;
 
+        /***
+            wrap function.
+            Takes a target 'Print' object and extends it with the PrintEx API.
+            This allows using a single object to manipulate the object's main
+            functionality, but also the PrintEx enhancements through a single
+            identifier.
+        ***/
+
         template<typename T>
         static PrintExWrap<T> &wrap( T &t ){
             return *transform<PrintExWrap<T>*, T*>(&t);
         }
 
+        /***
+            stdout handling.
+            The global function printf uses _stdout as a target for printing.
+        ***/
+
         #ifndef PRINTEX_NO_STDOUT
             static Print *_stdout;
+            inline static set_stdout( Print *out ){ _stdout = out; }
         #endif
     };
 

--- a/src/lib/PrintExtension.h
+++ b/src/lib/PrintExtension.h
@@ -33,8 +33,10 @@
     #define PRINTEX_NO_FLOATING_POINT
     #define PRINTEX_NO_REPEAT
     #define PRINTEX_NO_ERROR_CONDITION
-    #define PRINTEX_NO_SPRINTF
     #define PRINTEX_LARGE_COUNTER
+
+    #define PRINTEX_NO_SPRINTF
+	#define PRINTEX_NO_STDOUT
 ********************************************************************************/
 
 #include "Arduino.h"
@@ -53,6 +55,18 @@
     #else
         typedef uint8_t pfct;
     #endif
+	
+	namespace std{
+		#ifndef PRINTEX_NO_STDOUT
+		
+			template<signed N>
+			pft printf( const char (&format)[N], ... );
+			
+			#ifndef PRINTEX_NO_PROGMEM
+				pft printf( const __FlashStringHelper *format, ... );
+			#endif
+		#endif
+	};			
 
     class PrintExtension
         :   public Print,
@@ -75,6 +89,16 @@
 
             pft _printf( const char *format, const va_list &v_List );
 
+			#ifndef PRINTEX_NO_STDOUT
+			
+				template<signed N>
+				friend pft std::printf( const char (&format)[N], ... );
+				
+				#ifndef PRINTEX_NO_PROGMEM
+					friend pft std::printf( const __FlashStringHelper *format, ... );
+				#endif
+			#endif
+
             #ifndef PRINTEX_NO_PROGMEM
                 pft _printf( const __FlashStringHelper *format, const int count, const va_list &vList );
             #endif
@@ -95,6 +119,10 @@
         static PrintExWrap<T> &wrap( T &t ){
             return *transform<PrintExWrap<T>*, T*>(&t);
         }
+		
+		#ifndef PRINTEX_NO_STDOUT
+			static Print *_stdout;
+		#endif
     };
 
     template<typename T>
@@ -159,5 +187,25 @@
     #ifndef PRINTEX_NO_SPRINTF
         #define sprintf(buff, str, ...) GString(buff).printf(str, __VA_ARGS__);
     #endif
+	namespace std{
+		#ifndef PRINTEX_NO_STDOUT
+		
+			template<signed N>
+			pft printf( const char (&format)[N], ... ){
+				va_list vList;
+				va_start( vList, format );
+				PrintEx p = *PrintEx::_stdout;			
+				const pft p_Return = p._printf(format, vList);
+				va_end( vList );
+				return p_Return;	
+			}
+			
+			#ifndef PRINTEX_NO_PROGMEM
+				pft printf( const __FlashStringHelper *format, ... );
+			#endif
+		#endif
+	};
+	
+	//using ::std::printf;
 
 #endif


### PR DESCRIPTION
**Update:**

This is a proposal to add a replacement for the global `printf` function.

See: https://github.com/Chris--A/PrintEx/pull/20#issuecomment-235508973

The rest of this PR text is outdated, as new possibilities have become available

---

**Original PR:**

It stores a reference to a Print object, which is typically tied to serial. The functions are:
- `xprintf( const char *format, ... );`
- `xprintf( const __FlashStringHelper *format, ... );`

However this is done through a define, which translates the call to a PrintEx::printf usage.

``` C++
#define xprintf(str, ...) PrintEx(*PrintEx::_stdout).printf(str, __VA_ARGS__);
```

Is related to conversation in issue #15
