### PR TITLE
Update to the printf specifiers.

### DIFF
--- a/src/lib/PrintExtension.cpp
+++ b/src/lib/PrintExtension.cpp
@@ -80,7 +80,7 @@
             Helper for printf.
     ****************************************************************/
 
-    inline void PrintExtension::cwrite( uint8_t data, pfct &counter ){
+    inline void PrintExtension::cwrite( const uint8_t &data, pfct &counter ){
         write( data );
         ++counter;
     }
@@ -154,10 +154,8 @@
 
     #pragma GCC diagnostic push
     #pragma GCC diagnostic ignored "-Wattributes"
-    #ifndef ISCPP11
-        bool formatTest( const char *&format, const char test ) __attribute__((always_inline));
-    #endif
-    CONSTEXPR bool formatTest( const char *&format, const char test ){
+    bool formatTest( const char *&format, const char test ) __attribute__((always_inline));
+    bool formatTest( const char *&format, const char test ){
         return *format == test ? ++format, true : false;
     }
     #pragma GCC diagnostic pop
@@ -218,8 +216,8 @@
                         width = width >= sizeof(int*) ? width : sizeof(int*);
                     }
 
-                    //Convert argument into a string.
-                    if( *format == CHAR_s ){                                                    //String.
+                    //String.
+                    if( *format == CHAR_s ){
                         char *c_Parameter = ( char* ) GetParam_int( vList );
                         convertStr.assign( c_Parameter, strlen( c_Parameter ) );
 
@@ -285,7 +283,7 @@
                         convertStr.assign( buffer, 1 );
 
                     #if ( defined( PRINTF_NO_EEPROM ) || defined( PRINTF_NO_FLOATING_POINT ) || defined( PRINTF_NO_PROGMEM ) ) && !defined( PRINTF_NO_ERROR_CONDITION )
-                        }else
+                        }else{
                             convertStr.print( PRINTF_ERROR_MESSAGE );
                     #else
                         }

--- a/src/lib/PrintExtension.cpp
+++ b/src/lib/PrintExtension.cpp
@@ -43,6 +43,7 @@
     #define CHAR_p             'p'
     #define CHAR_q             'q'
     #define CHAR_r             'r'
+    #define CHAR_S             'S'
     #define CHAR_s             's'
     #define CHAR_t             't'
     #define CHAR_u             'u'
@@ -128,7 +129,7 @@
             Specifier:
 
                 s:    String ( null terminated ).
-                t:    PROGMEM string. No formatting takes place, the string is printed directly.
+                S:    PROGMEM string. No formatting takes place, the string is printed directly.
                 q:    EEPROM string. No formatting takes place, the string is printed directly.
                 d:    Signed decimal integer ( 32bits max ).
                 i:    Same as 'd'.
@@ -247,7 +248,7 @@
 
                     //PROGMEM functionality.
                     #ifndef PRINTF_NO_PROGMEM
-                        }else if( *format == CHAR_t ){
+                        }else if( *format == CHAR_S ){
                             counter += print( PString( ( void* ) GetParam_int( vList ) ) );
                             continue;
                     #endif

--- a/src/lib/PrintExtension.cpp
+++ b/src/lib/PrintExtension.cpp
@@ -113,7 +113,7 @@
                     q:  When using '%q' to read the EEPROM the width is the number of
                         characters to read.
 
-                    n:  Number of times to run repeat function.
+                    r:  Number of times to run repeat function.
 
             Precision:
 
@@ -160,8 +160,6 @@
         }
     #endif
 
-
-
     pft PrintExtension::printf( const char *format, ... ){
         va_list vList;
         va_start( vList, format );
@@ -182,8 +180,6 @@
     void parseValue( const char *&format, unsigned int &total ){
         for ( ; *format >= CHAR_ZERO && *format <= CHAR_NINE; ++format )(total *= 10) += *format - CHAR_ZERO;
     }
-
-
 
 
     pft PrintExtension::_printf( const char *format, const va_list &vList ){

--- a/src/lib/PrintExtension.cpp
+++ b/src/lib/PrintExtension.cpp
@@ -33,19 +33,21 @@
     #define CHAR_HASH          '#'
     #define CHAR_PERIOD        '.'
 
-    #define CHAR_s             's'
+    #define CHAR_c             'c'
     #define CHAR_d             'd'
-    #define CHAR_i             'i'
     #define CHAR_F             'F'
     #define CHAR_f             'f'
+    #define CHAR_i             'i'
+    #define CHAR_l             'l'
+    #define CHAR_n             'n'
+    #define CHAR_p             'p'
+    #define CHAR_q             'q'
+    #define CHAR_r             'r'
+    #define CHAR_s             's'
+    #define CHAR_t             't'
+    #define CHAR_u             'u'
     #define CHAR_x             'x'
     #define CHAR_X             'X'
-    #define CHAR_u             'u'
-    #define CHAR_c             'c'
-    #define CHAR_l             'l'
-    #define CHAR_p             'p'
-    #define CHAR_r             'r'
-    #define CHAR_n             'n'
 
     #define PAD_RIGHT           1
     #define PAD_ZERO            2
@@ -107,7 +109,7 @@
 
                 Extra:
 
-                    r:  When using 'r' to read the EEPROM the width is the number of
+                    q:  When using '%q' to read the EEPROM the width is the number of
                         characters to read.
 
                     n:  Number of times to run repeat function.
@@ -121,20 +123,24 @@
 
                 l:  d, i use long instead of int.
                     u, x use unsigned long instead of unsigned int.
-                    n    repeats a string.
+                    r    repeats a string.
 
             Specifier:
 
                 s:    String ( null terminated ).
-                p:    PROGMEM string. No formatting takes place, the string is printed directly.
-                r:    EEPROM string. No formatting takes place, the string is printed directly.
+                t:    PROGMEM string. No formatting takes place, the string is printed directly.
+                q:    EEPROM string. No formatting takes place, the string is printed directly.
                 d:    Signed decimal integer ( 32bits max ).
                 i:    Same as 'd'.
                 u:    Unsigned decimal integer ( 32bits max ).
                 f:    Decimal floating point number.
+                F:    Same as 'f'.
                 x:    Unsigned decimal integer ( 32bits max ).
+                X:    Same as 'x'
                 c:    Character.
-                n:    Repeat function ( default character, see length ).
+                r:    Repeat function ( default character, see length ).
+                n:    Parameter is a signed int*. The current output count will be written to pointer.
+                p:    Will write a pointer address. It is a hexadecimal print out formatted to 0x0000
                 %:    Escape character for printing '%'
     ****************************************************************/
 
@@ -205,25 +211,40 @@
                     //Get length flag if for larger types.
                     if( formatTest( format, CHAR_l ) ) largeType = true;
 
+                    //Print a pointer.
+                    if( *format == CHAR_p ){
+                        counter += write("0x");
+                        padChar = CHAR_ZERO;
+                        width = width >= sizeof(int*) ? width : sizeof(int*);
+                    }
+
                     //Convert argument into a string.
                     if( *format == CHAR_s ){                                                    //String.
                         char *c_Parameter = ( char* ) GetParam_int( vList );
                         convertStr.assign( c_Parameter, strlen( c_Parameter ) );
 
+                    //Return counter function.
+                    }else if( *format == CHAR_n ){
+                        *(signed int*) GetParam_int( vList ) = counter;
+                        continue;
+
+                    //PROGMEM functionality.
                     #ifndef PRINTF_NO_PROGMEM
-                        }else if( *format == CHAR_p ){
+                        }else if( *format == CHAR_t ){
                             counter += print( PString( ( void* ) GetParam_int( vList ) ) );
                             continue;
                     #endif
 
+                    //EEPROM handling.
                     #ifndef PRINTF_NO_EEPROM
-                        }else if( *format == CHAR_r ){
+                        }else if( *format == CHAR_q ){
                             counter += print( EString( ( void* ) GetParam_int( vList ), width ) );
                             continue;
                     #endif
 
+                    //Repeat function.
                     #ifndef PRINTF_NO_REPEAT
-                        }else if( *format == CHAR_n ){
+                        }else if( *format == CHAR_r ){
                             const int i_Data = GetParam_int( vList );
                             while( width-- ){
                                 if( largeType ) counter += print( ( char* ) i_Data );
@@ -232,16 +253,19 @@
                             continue;
                     #endif
 
-                    }else if( *format == CHAR_d ||  *format == CHAR_i ){                         //Signed decimal integer.
+                    //Signed decimal integer.
+                    }else if( *format == CHAR_d ||  *format == CHAR_i ){
                         if( largeType ) convertStr.print( va_arg( vList, int32_t ), DEC );
                         else            convertStr.print( ( int32_t ) GetParam_int( vList ), DEC );
 
-                    }else if( *format == CHAR_u ){                                                //Unsigned integer.
+                    //Unsigned integer.
+                    }else if( *format == CHAR_u ){
                         if( largeType ) convertStr.print( GetParam_uint( vList, false ), DEC );
                         else            convertStr.print( ( uint32_t ) GetParam_uint( vList, true ), DEC );
 
+                    //Floating point data.
                     #ifndef PRINTF_NO_FLOATING_POINT
-                        }else if( *format == CHAR_f ){                                            //Floating point data.
+                        }else if( *format == CHAR_f || *format == CHAR_F ){
                             #ifndef PRINTEX_NO_PRECISION_PARAM
                                 convertStr.print( va_arg( vList, double ), precision );
                             #else
@@ -249,13 +273,16 @@
                             #endif
                     #endif
 
-                    }else if( *format == CHAR_x ){                                                //Unsigned hexidecimal integer.
+                    //Unsigned hexadecimal integer.
+                    }else if( *format == CHAR_x || *format == CHAR_X || *format == CHAR_p ){
                         if( largeType ) convertStr.print( GetParam_uint( vList, false ), HEX );
                         else            convertStr.print( ( uint32_t ) GetParam_uint( vList, true ), HEX );
 
-                    }else if(  *format == CHAR_c ){                                                //Character.
+                    //Character.
+                    }else if(  *format == CHAR_c ){
                         *buffer = ( char ) GetParam_int( vList );
-                        convertStr.assign( buffer, 1 ); //This is cheaper than printing.
+                        //This is cheaper than printing.
+                        convertStr.assign( buffer, 1 );
 
                     #if ( defined( PRINTF_NO_EEPROM ) || defined( PRINTF_NO_FLOATING_POINT ) || defined( PRINTF_NO_PROGMEM ) ) && !defined( PRINTF_NO_ERROR_CONDITION )
                         }else

--- a/src/lib/PrintExtension.h
+++ b/src/lib/PrintExtension.h
@@ -72,7 +72,7 @@
             pft _printf( const char *format, const va_list &v_List );
 
         private:
-            void cwrite( uint8_t data, pfct &counter );
+            void cwrite( const uint8_t &data, pfct &counter );
     };
 
     //Forward declaration as PrintEx uses PrintExWrap


### PR DESCRIPTION
This layout gives a closer match in specifiers to commonly used printf implementations such as the ones found in the AVR core.

``` C++
/*
s:    String ( null terminated ).
S:    PROGMEM string. No formatting takes place, the string is printed directly.
q:    EEPROM string. No formatting takes place, the string is printed directly.
d:    Signed decimal integer ( 32bits max ).
i:    Same as 'd'.
u:    Unsigned decimal integer ( 32bits max ).
f:    Decimal floating point number.
F:    Same as 'f'.
x:    Unsigned decimal integer ( 32bits max ).
X:    Same as 'x'
c:    Character.
r:    Repeat function ( default character, see length ).
n:    Parameter is a signed int*. The current output count will be written to pointer.
p:    Will write a pointer address. It is a hexadecimal print out formatted to 0x0000
%:    Escape character for printing '%'
*/
```

Repeat has changed to `n` and was `r`.
Flash strings has changed to `S` and was `p`.

A new feature for `p` has been added and will write a pointer address.
A new feature for `n` has been added and will return a count of characters printed so far.

On testing, the code for a Mega 2560 increased by 85 bytes with the new features.
