### PR TITLE
add is_enum to insure that bit shifts are not mistaken for io stream operators

### DIFF
--- a/src/lib/TypeTraits.h
+++ b/src/lib/TypeTraits.h
@@ -106,6 +106,8 @@
     template < typename T, typename U > struct is_same : false_type{};
     template < typename T > struct is_same< T, T > : true_type{};
 
+    template<typename T> struct is_enum : public integral_constant<bool, __is_enum(T)>{};
+
     template< typename T >
         struct is_integer{
             enum{
@@ -232,6 +234,7 @@
         template<class B, class D>
             struct is_base_of<B,D,typename enable_if<
                 !is_array<D>::value &&
+                !is_enum<D>::value &&
                 !is_fundamental<D>::value &&
                 !is_pointer<D>::value>::type
             >{
@@ -245,7 +248,8 @@
         template<class B, class D>
             struct is_base_of<B,D,typename enable_if<
                 is_array<D>::value ||
-                is_fundamental<D>::value ||
+                is_enum<D>::value ||
+                is_fundamental<D>::value||
                 is_pointer<D>::value>::type
             >{
             static const bool value = 0;


### PR DESCRIPTION
The following sketch fails with the baseline PrintEx and compiles with this pull request

  #include <PrintEx.h>
  
  enum pin_t {
    D0 = 0x61,
  };
  
  void setup() {
    // libraries\PrintEx\src/lib/TypeTraits.h:239:22: error: base type 'pin_t' fails to be a struct or class type
    int reg = D0 >> 4;
  }
  
  void loop() {
    // put your main code here, to run repeatedly:
  
  }